### PR TITLE
Fixed bindgen code not being public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod vjoy_bindgen;
+pub use vjoy_bindgen::*;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Hello,
Just tried to use your crate but it looks like you made a oversight. All structures, enums and consts are kept private within the `vjoy_bindgen` module and cannot be seen by the crate's users. This PR simply `pub use` them in the main module.